### PR TITLE
set -ferror-limit=0 on clang to prevent errors in clangd

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks: 'cert-*,clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,google-*,misc-*,modernize-*,performance-*,portability-*,readability-*,bugprone-*,-cppcoreguidelines-non-private-member-variables-in-classes,-misc-non-private-member-variables-in-classes,-google-readability-casting,-clang-analyzer-optin.cplusplus.UninitializedObject,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-core.NullDereference'
 WarningsAsErrors: 'cert-*,clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,google-*,misc-*,modernize-*,performance-*,portability-*,readability-*,bugprone-*,-cppcoreguidelines-non-private-member-variables-in-classes,-misc-non-private-member-variables-in-classes,-google-readability-casting,-clang-analyzer-optin.cplusplus.UninitializedObject,-clang-analyzer-cplusplus.NewDeleteLeaks,-misc-include-cleaner,-clang-analyzer-core.NullDereference'
 HeaderFilterRegex: '(hyperion)$'
-AnalyzeTemporaryDtors: true
 FormatStyle: none
 User: braxton
 UseColor: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +63,7 @@ jobs:
           if [[ ${{matrix.version}} == 20 \
           ]]; then
             sudo ./llvm.sh ${{matrix.version}}
+            sudo apt-get install -y clang-tidy-${{matrix.version}}
           else
             sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
           fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Install LLVM
         run: |
           brew install llvm@${{matrix.version}}
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
+          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [16, 17, 18, 19, 20]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Install LLVM
         run: |
           brew install llvm@${{matrix.version}}
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
           echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,8 +60,12 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh all
-          sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
+          if [[ ${{matrix.version}} == 20 \
+          ]]; then
+            sudo ./llvm.sh ${{matrix.version}}
+          else
+            sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
+          fi
 
       - name: Replace clang-tidy
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [12, 13]
+        version: [12, 13, 14, 15]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -60,11 +60,16 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.version}}
-          sudo apt-get -y install clang-tidy-${{matrix.version}}
+          sudo ./llvm.sh all
+          sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
 
       - name: Replace clang-tidy
-        run: sudo cp /usr/bin/clang-tidy-${{matrix.version}} /usr/bin/clang-tidy -f
+        run: |
+          if [[ "$(realpath --canonicalize-existing /usr/bin/clang-tidy-${{matrix.version}})" \
+              != "$(realpath --canonicalize-existing /usr/bin/clang-tidy)" \
+          ]]; then
+            sudo cp /usr/bin/clang-tidy-${{matrix.version}} /usr/bin/clang-tidy -f
+          fi
 
       - name: Configure
         env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [12, 13, 14, 15]
+        version: [12, 13, 14]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update apt
+        run: sudo apt-get -y update
+
       - name: Install Doxygen
         run: sudo apt-get -y install doxygen
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt-get -y install graphviz
 
       - name: Install LibGS
-        run: sudo apt-get -y install libgs9 libgs9-common
+        run: sudo apt-get -y install libgs libgs-common
 
       - name: Install GCC 12
         run: sudo apt-get -y install gcc-12

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         run: sudo apt-get -y install graphviz
 
       - name: Install LibGS
-        run: sudo apt-get -y install libgs libgs-common
+        run: sudo apt-get -y install libgs10 libgs10-common
 
       - name: Install GCC 12
         run: sudo apt-get -y install gcc-12

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [12, 13]
+        version: [12, 13, 14, 15]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -79,11 +79,16 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.version}}
-          sudo apt-get -y install clang-tidy-${{matrix.version}}
+          sudo ./llvm.sh all
+          sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
 
       - name: Replace clang-tidy
-        run: sudo cp /usr/bin/clang-tidy-${{matrix.version}} /usr/bin/clang-tidy -f
+        run: |
+          if [[ "$(realpath --canonicalize-existing /usr/bin/clang-tidy-${{matrix.version}})" \
+              != "$(realpath --canonicalize-existing /usr/bin/clang-tidy)" \
+          ]]; then
+            sudo cp /usr/bin/clang-tidy-${{matrix.version}} /usr/bin/clang-tidy -f
+          fi
 
       - name: Configure
         working-directory: ${{github.workspace}}

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -82,6 +82,7 @@ jobs:
           if [[ ${{matrix.version}} == 20 \
           ]]; then
             sudo ./llvm.sh ${{matrix.version}}
+            sudo apt-get install -y clang-tidy-${{matrix.version}}
           else
             sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
           fi

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -206,11 +206,12 @@ jobs:
 
       - name: Configure
         working-directory: ${{github.workspace}}
+        env:
+          CC: $(brew --prefix llvm@${{matrix.version}})/bin/clang
+          CXX: $(brew --prefix llvm@${{matrix.version}})/bin/clang++
+          LDFLAGS: '-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'
         run: |
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
-          echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
-          echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
-          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
@@ -235,11 +236,11 @@ jobs:
       - name: Install Package
         env:
           ACTIONS_STEP_DEBUG: true
+          CC: $(brew --prefix llvm@${{matrix.version}})/bin/clang
+          CXX: $(brew --prefix llvm@${{matrix.version}})/bin/clang++
+          LDFLAGS: '-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'
         run: |
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
-          echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
-          echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
-          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
           xrepo install -y --toolchain=clang-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -204,6 +204,7 @@ jobs:
         run: |
           brew install llvm@${{matrix.version}}
           echo "$(brew --prefix llvm@${{matrix.version}})/bin"
+          ln -s "$(brew --prefix llvm@${{matrix.version}})/bin/clang++" "$(brew --prefix llvm@${{matrix.version}})/bin/clang++-${{matrix.version}}"
           ls "$(brew --prefix llvm@${{matrix.version}})/bin"
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -203,14 +203,13 @@ jobs:
       - name: Install LLVM
         run: |
           brew install llvm@${{matrix.version}}
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
-          echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
-          echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
-          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
 
       - name: Configure
         working-directory: ${{github.workspace}}
-        run: xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
+        run: |
+          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
+          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
+          xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
         env:
@@ -235,6 +234,8 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: true
         run: |
+          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
+          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
           xrepo install -y --toolchain=clang-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -223,7 +223,12 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           xmake b
-          xmake check clang.tidy
+          # disable clang-tidy on clang 19 and 20 because it is scanning errors
+          # within standard library headers
+          if [[ ${{matrix.version}} != 19 && ${{matrix.version}} != 20 \
+          ]]; then
+            xmake check clang.tidy
+          fi
 
       - name: Test
         env:

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Configure
         working-directory: ${{github.workspace}}
-        run: xmake f -c -y --toolchain=clang-{{matrix.version}} --hyperion_enable_tracy=y
+        run: xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
         env:
@@ -237,6 +237,6 @@ jobs:
         run: |
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
-          xrepo install -y --toolchain=clang-{{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
-          xrepo install -y --toolchain=clang-{{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-${{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
 

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -214,7 +214,7 @@ jobs:
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
           xmake project -k compile_commands
-          sed -i 's|"-I"|"-isystem"|g' compile_commands.json
+          sed -i 's|\"-I\"|\"-isystem\"|g' compile_commands.json
           cat compile_commands.json
 
       - name: Build

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -203,13 +203,13 @@ jobs:
       - name: Install LLVM
         run: |
           brew install llvm@${{matrix.version}}
+          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
 
       - name: Configure
         working-directory: ${{github.workspace}}
         run: |
-          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           xmake show -l toolchains
-          xmake f -c -y --toolchain=llvm-${{matrix.version}} --hyperion_enable_tracy=y
+          xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
         env:
@@ -234,9 +234,8 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: true
         run: |
-          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
-          xrepo install -y --toolchain=llvm-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
-          xrepo install -y --toolchain=llvm-${{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-${{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
 

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [16, 17, 18, 19, 20]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        version: [15, 16, 17, 18]
+        version: [15, 16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -153,9 +153,6 @@ jobs:
       - name: Install XMake
         run: |
           scoop install xmake
-          xmake update -sfy master
-          Start-Sleep -Seconds 2
-          xmake update -fy master
 
       - name: Configure
         working-directory: ${{github.workspace}}

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -207,6 +207,8 @@ jobs:
           ln -s "$(brew --prefix llvm@${{matrix.version}})/bin/clang++" "$(brew --prefix llvm@${{matrix.version}})/bin/clang++-${{matrix.version}}"
           ls "$(brew --prefix llvm@${{matrix.version}})/bin"
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
+          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I$(brew --prefix llvm@{{matrix.version}})/include"
 
       - name: Configure
         working-directory: ${{github.workspace}}

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [12, 13, 14, 15]
+        version: [12, 13, 14]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20]
+        version: [16, 17, 18, 19, 20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
 
       - name: Configure
         working-directory: ${{github.workspace}}
-        run: xmake f -c -y --toolchain=clang --hyperion_enable_tracy=y
+        run: xmake f -c -y --toolchain=clang-{{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
         env:
@@ -237,6 +237,6 @@ jobs:
         run: |
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
-          xrepo install -y --toolchain=clang "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
-          xrepo install -y --toolchain=clang --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-{{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=clang-{{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
 

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -208,6 +208,7 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
+          xmake show -l toolchains
           xmake f -c -y --toolchain=llvm-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -79,8 +79,12 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh all
-          sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
+          if [[ ${{matrix.version}} == 20 \
+          ]]; then
+            sudo ./llvm.sh ${{matrix.version}}
+          else
+            sudo apt-get install -y llvm-${{matrix.version}} clang-${{matrix.version}} clang-tidy-${{matrix.version}}
+          fi
 
       - name: Replace clang-tidy
         run: |

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -207,14 +207,13 @@ jobs:
           ln -s "$(brew --prefix llvm@${{matrix.version}})/bin/clang++" "$(brew --prefix llvm@${{matrix.version}})/bin/clang++-${{matrix.version}}"
           ls "$(brew --prefix llvm@${{matrix.version}})/bin"
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
-          echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$(brew --prefix llvm@{{matrix.version}})/include"
 
       - name: Configure
         working-directory: ${{github.workspace}}
         run: |
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
+          xmake project -k compile_commands
 
       - name: Build
         env:

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -203,6 +203,8 @@ jobs:
       - name: Install LLVM
         run: |
           brew install llvm@${{matrix.version}}
+          echo "$(brew --prefix llvm@${{matrix.version}})/bin"
+          ls "$(brew --prefix llvm@${{matrix.version}})/bin"
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
 
       - name: Configure

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -214,7 +214,7 @@ jobs:
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
           xmake project -k compile_commands
-          sed -i 's/"-I"/"-isystem"/g' compile_commands.json
+          sed -i '' 's/"-I"/"-isystem"/g' compile_commands.json
           cat compile_commands.json
 
       - name: Build

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Configure
         working-directory: ${{github.workspace}}
         run: |
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
+          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
@@ -236,7 +236,7 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: true
         run: |
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
+          echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -207,7 +207,9 @@ jobs:
       - name: Configure
         working-directory: ${{github.workspace}}
         run: |
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
 
@@ -234,7 +236,9 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: true
         run: |
-          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$(brew --prefix llvm@${{matrix.version}})/bin:$($PATH)" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm@${{matrix.version}})/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix llvm@${{matrix.version}})/bin/clang++" >> $GITHUB_ENV
           echo "LDFLAGS='-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'" >> $GITHUB_ENV
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -206,13 +206,9 @@ jobs:
 
       - name: Configure
         working-directory: ${{github.workspace}}
-        env:
-          CC: $(brew --prefix llvm@${{matrix.version}})/bin/clang
-          CXX: $(brew --prefix llvm@${{matrix.version}})/bin/clang++
-          LDFLAGS: '-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'
         run: |
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
-          xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
+          xmake f -c -y --toolchain=llvm-${{matrix.version}} --hyperion_enable_tracy=y
 
       - name: Build
         env:
@@ -236,13 +232,10 @@ jobs:
       - name: Install Package
         env:
           ACTIONS_STEP_DEBUG: true
-          CC: $(brew --prefix llvm@${{matrix.version}})/bin/clang
-          CXX: $(brew --prefix llvm@${{matrix.version}})/bin/clang++
-          LDFLAGS: '-L$(brew --prefix llvm@${{matrix.version}})/lib/c++ -Wl,-rpath,$(brew --prefix llvm@${{matrix.version}})/lib/c++'
         run: |
           echo "$(brew --prefix llvm@${{matrix.version}})/bin" >> $GITHUB_PATH
           xrepo add-repo -y hyperion "https://github.com/braxtons12/hyperion_packages.git"
           xrepo update-repo -y
-          xrepo install -y --toolchain=clang-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
-          xrepo install -y --toolchain=clang-${{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=llvm-${{matrix.version}} "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
+          xrepo install -y --toolchain=llvm-${{matrix.version}} --configs="hyperion_enable_tracy=true" "hyperion_platform ${{ steps.extract_branch.outputs.branch }}"
 

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -214,6 +214,7 @@ jobs:
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
           xmake project -k compile_commands
+          cat compile_commands.json
 
       - name: Build
         env:

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -214,6 +214,7 @@ jobs:
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
           xmake project -k compile_commands
+          sed -i 's|"-I"|"-isystem"|g' compile_commands.json
           cat compile_commands.json
 
       - name: Build

--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -214,7 +214,7 @@ jobs:
           xmake show -l toolchains
           xmake f -c -y --toolchain=clang-${{matrix.version}} --hyperion_enable_tracy=y
           xmake project -k compile_commands
-          sed -i 's|\"-I\"|\"-isystem\"|g' compile_commands.json
+          sed -i 's/"-I"/"-isystem"/g' compile_commands.json
           cat compile_commands.json
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(hyperion_platform LANGUAGES CXX VERSION 0.5.3)
+project(hyperion_platform LANGUAGES CXX VERSION 0.5.4)
 
 include(CTest)
 

--- a/cmake/hyperion_compiler_settings.cmake
+++ b/cmake/hyperion_compiler_settings.cmake
@@ -46,7 +46,7 @@ function(hyperion_compile_settings TARGET)
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMILER_ID STREQUAL "clang")
-        target_compile_options(${TARGET} ${PUBLIC_VISIBILITY} -fsized-deallocation)
+        target_compile_options(${TARGET} ${PUBLIC_VISIBILITY} -fsized-deallocation -ferror-limit=0)
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMILER_ID STREQUAL "clang")

--- a/src/test_main.cpp
+++ b/src/test_main.cpp
@@ -1,8 +1,8 @@
 /// @file test_main.cpp
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Unit tests main for hyperion::platform.
-/// @version 0.1
-/// @date 2024-09-22
+/// @version 0.1.1
+/// @date 2025-07-09
 ///
 /// MIT License
 /// @copyright Copyright (c) 2024 Braxton Salyer <braxtonsalyer@gmail.com>
@@ -25,6 +25,7 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
 
+#include <hyperion/platform.h>
 #include <hyperion/platform/types.h>
 
 #include <boost/ut.hpp>

--- a/xmake.lua
+++ b/xmake.lua
@@ -16,6 +16,8 @@ end)
 
 if has_config("hyperion_enable_tracy") then
     add_requires("tracy", {
+        system = false,
+        external = true,
         configs = {
             languages = "cxx20"
         }
@@ -23,12 +25,16 @@ if has_config("hyperion_enable_tracy") then
 end
 
 add_requires("fast_float", {
+    system = false,
+    external = true,
     configs = {
         languages = "cxx20",
     },
 })
 
 add_requires("boost_ut", {
+    system = false,
+    external = true,
     configs = {
         modules = false,
         languages = "cxx20",

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: undefined-global,undefined-field
 set_project("hyperion_platform")
-set_version("0.5.3")
+set_version("0.5.4")
 
 set_xmakever("3.0.0")
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -2,7 +2,7 @@
 set_project("hyperion_platform")
 set_version("0.5.3")
 
-set_xmakever("2.8.7")
+set_xmakever("3.0.0")
 
 set_languages("cxx20")
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -17,7 +17,6 @@ end)
 if has_config("hyperion_enable_tracy") then
     add_requires("tracy", {
         system = false,
-        external = true,
         configs = {
             languages = "cxx20"
         }
@@ -26,7 +25,6 @@ end
 
 add_requires("fast_float", {
     system = false,
-    external = true,
     configs = {
         languages = "cxx20",
     },
@@ -34,7 +32,6 @@ add_requires("fast_float", {
 
 add_requires("boost_ut", {
     system = false,
-    external = true,
     configs = {
         modules = false,
         languages = "cxx20",

--- a/xmake.lua
+++ b/xmake.lua
@@ -16,7 +16,6 @@ end)
 
 if has_config("hyperion_enable_tracy") then
     add_requires("tracy", {
-        system = false,
         configs = {
             languages = "cxx20"
         }
@@ -24,14 +23,12 @@ if has_config("hyperion_enable_tracy") then
 end
 
 add_requires("fast_float", {
-    system = false,
     configs = {
         languages = "cxx20",
     },
 })
 
 add_requires("boost_ut", {
-    system = false,
     configs = {
         modules = false,
         languages = "cxx20",

--- a/xmake/hyperion_compiler_settings.lua
+++ b/xmake/hyperion_compiler_settings.lua
@@ -50,6 +50,7 @@ local function _set_compile_options(target)
         target:add("cxflags", "/sdl", { public = false })
     elseif target:has_tool("cxx", "clang", "clang++") then
         target:add("cxflags", "-fsized-deallocation", { public = true })
+        target:add("cxflags", "-ferror-limit=0", { public = true })
     end
 end
 

--- a/xmake/hyperion_compiler_settings.lua
+++ b/xmake/hyperion_compiler_settings.lua
@@ -15,7 +15,12 @@ end
 
 local function _set_compile_options(target)
     if is_mode("release") then
-        target:set("optimize", "aggressive")
+        if target:has_tool("cxx", "clang", "clang++") then
+            -- clang 19 deprecates -Ofast, so just use -O3 on clang
+            target:set("optimize", "fastest")
+        else
+            target:set("optimize", "aggressive")
+        end
         if target:has_tool("cxx", "cl") then
             -- do not enable avx512 on MSVC is it has an optimizer error
             -- that will cause a crash due to misalignment


### PR DESCRIPTION
- set -ferror-limit=0 when compiling with clang to fix tooling issues (e.g. clangd)
- update supported LLVM versions in CI (add 19 and 20, remove 15)
- update supported GCC versions in CI (add 14)
- various CI fixes to work with latest runner images